### PR TITLE
Allow the coercion value to be directly tested.

### DIFF
--- a/lib/Test/TypeConstraints.pm
+++ b/lib/Test/TypeConstraints.pm
@@ -50,8 +50,9 @@ sub check_type {
     my ($tc, $value, %options) = @_;
 
     return 1 if $tc->check($value);
-    if ( $options{coerce} ) {
+    if ( my $coerce_check = $options{coerce} ) {
         my $new_val = $tc->coerce($value);
+        $coerce_check->($new_val) if ref $coerce_check;
         return 1 if $tc->check($new_val);
     }
 
@@ -83,20 +84,27 @@ Test::TypeConstraints is for testing whether some value is valid as (Moose|Mouse
     $typename_or_type is a Classname or Mouse::Meta::TypeConstraint name or "Mouse::Meta::TypeConstraint" object or "Moose::Meta::TypeConstraint::Class" object.
     %options is Hash. value is followings:
 
-=head3 coerce: Bool
+=head3 coerce: Bool or CodeRef
 
-        try coercion when checking value.
+If true, it will try coercion when checking a value.
+
+If a CodeRef is given, it will be run and passed in the coerced value
+for additional testing.
+
+    type_isa $value, "Some::Class", "coerce to Some::Class", coerce => sub {
+        isa_ok $_[0], "Some::Class";
+        is $_[0]->value, $value;
+    };
 
 =head2 type_does($got, $rolename_or_role, $test_name, %options)
 
     $got is value for checking.
     $typename_or_type is a Classname or Mouse::Meta::TypeConstraint name or "Mouse::Meta::TypeConstraint" object or "Moose::Meta::TypeConstraint::Role" object.
-
     %options is Hash. value is followings:
 
-=head3 coerce: Bool
+=head3 coerce: Bool or CodeRef
 
-        try coercion when checking value.
+Same as type_isa's coerce option.
 
 =head1 AUTHOR
 

--- a/t/04_coerce.t
+++ b/t/04_coerce.t
@@ -1,0 +1,32 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::TypeConstraints;
+use Test::More;
+
+use Mouse::Util::TypeConstraints;
+
+{
+    package Some::Class;
+    use Mouse;
+
+    has value =>
+      is  => 'ro',
+      isa => 'Str';
+}
+
+coerce "Some::Class" =>
+  from "Str",
+  via { Some::Class->new({ value => $_ }) };
+
+{
+    my $value = "something";
+    type_isa $value, "Some::Class", "coerce to Some::Class", coerce => sub {
+        isa_ok $_[0], "Some::Class";
+        is $_[0]->value, $value;
+    };
+}
+
+done_testing;


### PR DESCRIPTION
Not enough that it passes the type constraint, its also important that
the coercion results in the correct value.

For rt.cpan.org 82353.
